### PR TITLE
Fix deprecations and warnings in experta

### DIFF
--- a/experta/fact.py
+++ b/experta/fact.py
@@ -1,7 +1,6 @@
 from itertools import chain
 from functools import lru_cache
 import abc
-import collections
 
 from schema import Schema
 
@@ -9,6 +8,11 @@ from experta.pattern import Bindable
 from experta.utils import freeze, unfreeze
 from experta.conditionalelement import OperableCE
 from experta.conditionalelement import ConditionalElement
+
+try:
+    from collections.abc import Callable  # noqa
+except ImportError:
+    from collections import Callable  # noqa
 
 
 class BaseField(metaclass=abc.ABCMeta):
@@ -70,7 +74,7 @@ class Fact(OperableCE, Bindable, dict, metaclass=Validable):
                 raise KeyError(key)
             elif key in self.__defaults:
                 return self.__defaults[key]
-            elif isinstance(default, collections.abc.Callable):
+            elif isinstance(default, Callable):
                 return self.__defaults.setdefault(key, default())
             else:
                 return self.__defaults.setdefault(key, default)

--- a/experta/fieldconstraint.py
+++ b/experta/fieldconstraint.py
@@ -1,7 +1,10 @@
-from collections.abc import Callable
-
 from experta.conditionalelement import ConditionalElement
 from experta.pattern import Bindable
+
+try:
+    from collections.abc import Callable  # noqa
+except ImportError:
+    from collections import Callable  # noqa
 
 __all__ = ['L', 'W', 'P']
 

--- a/experta/matchers/rete/check.py
+++ b/experta/matchers/rete/check.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-from collections.abc import Mapping
 from functools import singledispatch
 import dis
 import inspect
@@ -10,6 +9,10 @@ from experta.fieldconstraint import ANDFC, ORFC, NOTFC
 from .abstract import Check
 from experta.watchers import MATCH
 
+try:
+    from collections.abc import Mapping  # noqa
+except ImportError:
+    from collections import Mapping  # noqa
 
 CheckFunction = namedtuple('CheckFunction',
                            ['key_a', 'key_b', 'expected', 'check'])
@@ -232,15 +235,15 @@ class FeatureCheck(Check,
 
 
 class SameContextCheck(Check):
-    def __call__(self, l, r):
-        for key, value in l.items():
+    def __call__(self, left, right):
+        for key, value in left.items():
             if key[0] is False:
                 raise RuntimeError(
                     'Negated value "%s" present before capture.' % key[1])
             else:
-                if key in r and value != r[key]:
+                if key in right and value != right[key]:
                     return False
-                if (False, key) in r and value == r[(False, key)]:
+                if (False, key) in right and value == right[(False, key)]:
                     return False
         else:
             return True

--- a/experta/matchers/rete/mixins.py
+++ b/experta/matchers/rete/mixins.py
@@ -1,6 +1,10 @@
 """Mixing classes for the RETE nodes."""
 from collections import namedtuple
-from collections.abc import Callable
+
+try:
+    from collections.abc import Callable  # noqa
+except ImportError:
+    from collections import Callable  # noqa
 
 
 #: Used to store node/callback pair in nodes children set.

--- a/experta/matchers/rete/nodes.py
+++ b/experta/matchers/rete/nodes.py
@@ -6,7 +6,6 @@ types (like `The One-input Node for Testing Variable Bindings) are not
 needed in this implementation.
 
 """
-from collections.abc import Mapping
 from contextlib import suppress
 from itertools import chain
 
@@ -17,6 +16,11 @@ from experta.watchers import MATCHER, MATCH
 from . import mixins
 from .abstract import Node, OneInputNode, TwoInputNode
 from .token import Token
+
+try:
+    from collections.abc import Mapping  # noqa
+except ImportError:
+    from collections import Mapping  # noqa
 
 
 class BusNode(mixins.AnyChild,

--- a/experta/matchers/rete/token.py
+++ b/experta/matchers/rete/token.py
@@ -1,10 +1,14 @@
 """Token object and related objects needed by the RETE algorithm."""
 
 from collections import namedtuple
-from collections.abc import Mapping
 from enum import Enum
 
 from experta.fact import Fact
+
+try:
+    from collections.abc import Mapping  # noqa
+except ImportError:
+    from collections import Mapping  # noqa
 
 
 class TokenInfo(namedtuple('_TokenInfo', ['data', 'context'])):

--- a/experta/rule.py
+++ b/experta/rule.py
@@ -1,9 +1,13 @@
-from collections.abc import Iterable
 from functools import update_wrapper
 import inspect
 
 from experta import watchers
 from experta.conditionalelement import ConditionalElement
+
+try:
+    from collections.abc import Iterable  # noqa
+except ImportError:
+    from collections import Iterable  # noqa
 
 
 class Rule(ConditionalElement):

--- a/experta/utils.py
+++ b/experta/utils.py
@@ -1,9 +1,13 @@
 from functools import singledispatch
-import collections.abc
 
-from frozendict import frozendict
+from immutabledict import immutabledict as frozendict
 
 from .fieldconstraint import P
+
+try:
+    from collections.abc import Hashable  # noqa
+except ImportError:
+    from collections import Hashable  # noqa
 
 
 class frozenlist(tuple):
@@ -13,7 +17,7 @@ class frozenlist(tuple):
 
 @singledispatch
 def freeze(obj):
-    if isinstance(obj, collections.abc.Hashable):
+    if isinstance(obj, Hashable):
         return obj
     else:
         raise TypeError(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,1 +1,3 @@
 [pytest]
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ url = https://github.com/nilp0inter/experta
 zip_safe = False
 include_package_data = True
 install_requires =
-  frozendict==1.2
+  immutabledict==1.0.0
   schema==0.6.7
 packages = find:
 


### PR DESCRIPTION
* Fix collections.abc warnings in Python 3.8
* Switch from frozendict to immutabledict to fix collections.abc
  warnings
* Fix pycodestyle warning for paramemeter naming
* Declare the slow marker to fix a pytest warning