### PR TITLE
Switch back from immutabledict to frozendict

### DIFF
--- a/experta/utils.py
+++ b/experta/utils.py
@@ -1,6 +1,6 @@
 from functools import singledispatch
 
-from immutabledict import immutabledict as frozendict
+from frozendict import frozendict
 
 from .fieldconstraint import P
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ url = https://github.com/nilp0inter/experta
 zip_safe = False
 include_package_data = True
 install_requires =
-  immutabledict==1.0.0
+  frozendict==2.0.2
   schema==0.6.7
 packages = find:
 


### PR DESCRIPTION
Frozendict library finally has a new owner, they already have updated the code, to make sure it's compatible with Python 3.8 and above – and now it's safe to use it again and don't use non-official forks.